### PR TITLE
[SamplePhotoApp] Add missing privacy key

### DIFF
--- a/ios9/SamplePhotoApp/SamplePhotoApp/Info.plist
+++ b/ios9/SamplePhotoApp/SamplePhotoApp/Info.plist
@@ -45,5 +45,7 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Sample App using the Photo Library</string>
 </dict>
 </plist>


### PR DESCRIPTION
Fix bug #44067: [iOS10]Monotouch application "SamplePhotoApp" crash as soon as it launch on device
(https://bugzilla.xamarin.com/show_bug.cgi?id=44067)