### PR TITLE
[HomeKitCatalog] Add missing privacy key

### DIFF
--- a/ios9/HomeKitCatalog/HomeKitCatalog/Info.plist
+++ b/ios9/HomeKitCatalog/HomeKitCatalog/Info.plist
@@ -43,5 +43,7 @@
 	<string>Main</string>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Images.xcassets/AppIcon.appiconset</string>
+	<key>NSHomeKitUsageDescription</key>
+	<string>Sample App using HomeKit</string>
 </dict>
 </plist>


### PR DESCRIPTION
Fix bug #44068: [iOS10]Monotouch application "HomeKitCatalog" crash as soon as it launches on device
(https://bugzilla.xamarin.com/show_bug.cgi?id=44068)