### PR TITLE
Fixed crash related to capture bracket view

### DIFF
--- a/ManualCameraControls/ManualCameraControls/BracketedViewController.cs
+++ b/ManualCameraControls/ManualCameraControls/BracketedViewController.cs
@@ -100,9 +100,14 @@ namespace ManualCameraControls
 				AVCaptureAutoExposureBracketedStillImageSettings.Create (2f)
 			};
 
+			OutputIndex = Settings.Length;
+
 			// Wireup capture button
 			CaptureButton.TouchUpInside += (sender, e) => {
 				// Reset output index
+				if (OutputIndex < Settings.Length)
+					return;
+				
 				OutputIndex = 0;
 
 				// Tell the camera that we are getting ready to do a bracketed capture


### PR DESCRIPTION
I added a required validation in order to avoid multiple Capture Bracket Camera calls.
https://bugzilla.xamarin.com/show_bug.cgi?id=43779