### PR TITLE
[AVCaptureFrames] Added iOS 10-required privacy description to info.plist

### DIFF
--- a/AVCaptureFrames/Info.plist
+++ b/AVCaptureFrames/Info.plist
@@ -45,5 +45,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>CFBundleName</key>
+	<string>Capt. Frames</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Demonstrate video capture</string>
 </dict>
 </plist>


### PR DESCRIPTION
Fixed problem where sample was auto-closed by iOS 10 increased privacy protections