### PR TITLE
Updated readme to include crown swipe from macbook

### DIFF
--- a/watchOS/WatchComplication/README.md
+++ b/watchOS/WatchComplication/README.md
@@ -9,7 +9,7 @@ To configure complications in the simulator:
 4. *Command+Shift+1* disables force-touch deep press
 5. Click on the **Configuration** button
 6. Click-drag to swipe left/right until you see the complications configuration
-7. Click on each configuration, and use the up & down arrows on the keyboard to simulate the Digital Crown
+7. Click on each configuration, and use the up & down arrows on the keyboard or swipe up & down on trackpad to simulate the Digital Crown
 8. One of the complications should be the one in your app (use `CFBundleDisplayName` to set the text displayed)
 
 ![](Screenshots/configure-complications.png)


### PR DESCRIPTION
While using MacBook up/down arrows on keyboard don't work, have to use swipe up/down on Trackpad.