### PR TITLE
Set deployment target to 9.0 

### DIFF
--- a/intro-to-extensions/ContainerApp/Info.plist
+++ b/intro-to-extensions/ContainerApp/Info.plist
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
-	<true />
+	<true/>
 	<key>MinimumOSVersion</key>
 	<string>9.0</string>
 	<key>UIDeviceFamily</key>
@@ -34,5 +34,7 @@
 	<string>Resources/images.xcassets/AppIcons.appiconset</string>
 	<key>XSLaunchImageAssets</key>
 	<string>Resources/images.xcassets/LaunchImage.launchimage</string>
+	<key>CFBundleName</key>
+	<string>ContainerApp</string>
 </dict>
 </plist>

--- a/intro-to-extensions/DayCountExtension/Info.plist
+++ b/intro-to-extensions/DayCountExtension/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Day Count Extension</string>
+	<string>com.xamarin.DayCountExtension</string>
 	<key>CFBundleExecutable</key>
 	<string>DayCountExtension</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>com.your-company.DayCountExtension</string>
+	<string>com.xamarin.DayCountExtension</string>
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
@@ -29,5 +29,7 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.widget-extension</string>
 	</dict>
+	<key>MinimumOSVersion</key>
+	<string>9.0</string>
 </dict>
 </plist>

--- a/ios10/ElizaChat/ElizaChat/ElizaChat.csproj
+++ b/ios10/ElizaChat/ElizaChat/ElizaChat.csproj
@@ -21,7 +21,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
     <MtouchFastDev>true</MtouchFastDev>
-    <MtouchProfiling>true</MtouchProfiling>
+    <MtouchProfiling>false</MtouchProfiling>
     <MtouchLink>None</MtouchLink>
     <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
@@ -68,7 +68,7 @@
     <DefineConstants>DEBUG;ENABLE_TEST_CLOUD;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodesignKey>iPhone Developer: Kevin Mullins (46FB3Q72SJ)</CodesignKey>
+    <CodesignKey>iPhone Developer</CodesignKey>
     <DeviceSpecificBuild>true</DeviceSpecificBuild>
     <MtouchDebug>true</MtouchDebug>
     <MtouchFastDev>true</MtouchFastDev>
@@ -80,7 +80,7 @@
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
-    <CodesignProvision>d9ead51a-1104-43ad-b162-86eebfaaa189</CodesignProvision>
+    <CodesignProvision></CodesignProvision>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/ios9/MetalPerformanceShadersHelloWorld/MetalPerformanceShadersHelloWorld/Info.plist
+++ b/ios9/MetalPerformanceShadersHelloWorld/MetalPerformanceShadersHelloWorld/Info.plist
@@ -25,5 +25,9 @@
 	<string>Main</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>CFBundleName</key>
+	<string>MetalPerformanceShaders</string>
+	<key>MinimumOSVersion</key>
+	<string>9.0</string>
 </dict>
 </plist>

--- a/ios9/MetalPerformanceShadersHelloWorld/MetalPerformanceShadersHelloWorld/MetalPerformanceShadersHelloWorld.csproj
+++ b/ios9/MetalPerformanceShadersHelloWorld/MetalPerformanceShadersHelloWorld/MetalPerformanceShadersHelloWorld.csproj
@@ -23,7 +23,6 @@
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
     <MtouchProfiling>true</MtouchProfiling>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchI18n>
     </MtouchI18n>
     <CodesignKey>iPhone Developer</CodesignKey>


### PR DESCRIPTION
Set code-signing to development/automatic in a sample app. Fixed deployment target of two sample apps to wokaround a build error if only 11.0 is targeted bug 58156.