### PR TITLE
CoreTelephony Demo and CameraRipple change

### DIFF
--- a/CoreTelephonyDemo/CoreTelephonyDemoViewController.cs
+++ b/CoreTelephonyDemo/CoreTelephonyDemoViewController.cs
@@ -103,9 +103,10 @@ namespace CoreTelephonyDemo
 			#region implemented abstract members of MonoTouch.UIKit.UITableViewDataSource
 			public override nint RowsInSection (UITableView tableView, nint section)
 			{
+                var controller = wcontroller.Target as CoreTelephonyDemoViewController;
 				switch ((SectionIndex) (int)section) {
 				case SectionIndex.CurrentCall:
-					return Math.Max (controller.calls.Length, 1);
+                        return Math.Max (controller.calls.Length, 1);
 				case SectionIndex.CallCenter:
 					return (int) SectionRow.CallCenter;
 				case SectionIndex.Carrier:

--- a/GLCameraRipple/RippleViewController.cs
+++ b/GLCameraRipple/RippleViewController.cs
@@ -279,7 +279,7 @@ namespace GLCameraRipple
 				wcontainer = new WeakReference<RippleViewController>(container);
 			}
 
-			void CleanupTextures (RippleViewController container)
+			void CleanupTextures ()
 			{
 				if (lumaTexture != null)
 					lumaTexture.Dispose ();
@@ -304,7 +304,7 @@ namespace GLCameraRipple
 								container.SetupRipple (textureWidth, textureHeight);
 							}
 
-							CleanupTextures (container);
+							CleanupTextures ();
 
 							// Y-plane
 							GL.ActiveTexture (TextureUnit.Texture0);


### PR DESCRIPTION
This fixes a build issue in core telephony introduced with the use of weak reference and also a fix in PR 174.