### PR TITLE
iOS 11 MapKit with clustering crash workaround

### DIFF
--- a/ios11/MapKitSample/Tandm/Classes/BikeView.cs
+++ b/ios11/MapKitSample/Tandm/Classes/BikeView.cs
@@ -58,6 +58,11 @@ namespace Tandm
 		public BikeView(IntPtr handle) : base(handle)
 		{
 		}
+
+        public BikeView(IMKAnnotation annotation, string identifier) : base(annotation, identifier)
+        {
+
+        }
 		#endregion
 
 

--- a/ios11/MapKitSample/Tandm/Classes/ClusterView.cs
+++ b/ios11/MapKitSample/Tandm/Classes/ClusterView.cs
@@ -81,7 +81,7 @@ namespace Tandm
 		{
 		}
 
-		public ClusterView(MKAnnotation annotation, string reuseIdentifier) : base(annotation, reuseIdentifier)
+		public ClusterView(IMKAnnotation annotation, string reuseIdentifier) : base(annotation, reuseIdentifier)
 		{
 			// Initialize
 			DisplayPriority = MKFeatureDisplayPriority.DefaultHigh;

--- a/ios11/MapKitSample/Tandm/ViewController.cs
+++ b/ios11/MapKitSample/Tandm/ViewController.cs
@@ -91,11 +91,12 @@ namespace Tandm
                 }
                 return view;
             }
-            else {
+            else if (annotation != null) {
                 var unwrappedAnnotation = MKAnnotationWrapperExtensions.UnwrapClusterAnnotation(annotation);
 
                 return HandleMKMapViewAnnotation(mapView, unwrappedAnnotation);
             }
+            return null;
         }
 		#endregion
 

--- a/ios11/MapKitSample/Tandm/ViewController.cs
+++ b/ios11/MapKitSample/Tandm/ViewController.cs
@@ -70,6 +70,33 @@ namespace Tandm
 				MapView.AddAnnotations(Bike.FromDictionaryArray(bikes));
 			}
 		}
+
+        private MKAnnotationView HandleMKMapViewAnnotation(MKMapView mapView, IMKAnnotation annotation)
+        {
+            if (annotation is Bike) {
+                var marker = annotation as Bike;
+
+                var view = mapView.DequeueReusableAnnotation(MKMapViewDefault.AnnotationViewReuseIdentifier) as BikeView;
+                if (view == null) {
+                    view = new BikeView(marker, MKMapViewDefault.AnnotationViewReuseIdentifier);
+                }
+                return view;
+            }
+            else if (annotation is MKClusterAnnotation) {
+                var cluster = annotation as MKClusterAnnotation;
+
+                var view = mapView.DequeueReusableAnnotation(MKMapViewDefault.ClusterAnnotationViewReuseIdentifier) as ClusterView;
+                if (view == null) {
+                    view = new ClusterView(cluster, MKMapViewDefault.ClusterAnnotationViewReuseIdentifier);
+                }
+                return view;
+            }
+            else {
+                var unwrappedAnnotation = MKAnnotationWrapperExtensions.UnwrapClusterAnnotation(annotation);
+
+                return HandleMKMapViewAnnotation(mapView, unwrappedAnnotation);
+            }
+        }
 		#endregion
 
 		#region Override Methods
@@ -81,6 +108,8 @@ namespace Tandm
 			SetupUserTrackingAndScaleView();
 			RegisterAnnotationViewClasses();
 			LoadDataForMapRegionAndBikes();
+
+            MapView.GetViewForAnnotation = HandleMKMapViewAnnotation;
 		}
 		#endregion
 	}


### PR DESCRIPTION
On iOS 11 an app using MapKit and the clustering crashes after a while as described on the following link : https://forums.developer.apple.com/thread/89427

This PR brings the workaround to the sample Tandm.