### PR TITLE
[XI] added `AllowUnsafeBlocks` attribute and modify the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.stamp
 bin
 obj
+.vs
 Newtonsoft.Json.*
 NUnit.*
 Xamarin.UITest*

--- a/InfColorPicker/InfColorPickerBinding/InfColorPickerBinding/InfColorPickerBinding.csproj
+++ b/InfColorPicker/InfColorPickerBinding/InfColorPickerBinding/InfColorPickerBinding.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>InfColorPicker</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>InfColorPickerBinding</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
- added AllowUnsafeBlocks attribute to groups where it was absent - because of it XI test failed 
- added a new ".vs" folder to the `.gitignore` file 