### PR TITLE
[XI] fixed the "Notification" sample

### DIFF
--- a/Notifications/Application.cs
+++ b/Notifications/Application.cs
@@ -1,20 +1,12 @@
-using System;
 using UIKit;
 
 namespace Example_Notifications
 {
-	public class Application// : UIApplication
+	public class Application
 	{
-		public static void Main (string[] args)
+		public static void Main(string[] args)
 		{
-			try
-			{
-				UIApplication.Main (args, null, "AppDelegate");
-			}
-			catch (Exception e)
-			{
-				Console.WriteLine (e.ToString ());
-			}
+			UIApplication.Main(args, null, "AppDelegate");
 		}
 	}
 }

--- a/Notifications/Entitlements.plist
+++ b/Notifications/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/Notifications/Info.plist
+++ b/Notifications/Info.plist
@@ -31,6 +31,6 @@
 	<key>CFBundleName</key>
 	<string>Notifications</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.xamarin.notifications</string>
+	<string>com.xamarin.allnotifications</string>
 </dict>
 </plist>

--- a/Notifications/Notifications.csproj
+++ b/Notifications/Notifications.csproj
@@ -57,6 +57,7 @@
     </MtouchI18n>
     <MtouchUseArmv7>false</MtouchUseArmv7>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
@@ -70,6 +71,7 @@
     </MtouchI18n>
     <MtouchUseArmv7>false</MtouchUseArmv7>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -94,7 +96,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Code\" />
     <Folder Include="Screens\" />
     <Folder Include="Screens\iPhone\" />
     <Folder Include="Screens\iPhone\Home\" />
@@ -103,6 +104,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />
+    <None Include="Entitlements.plist" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Screens\iPhone\Home\Home_iPhone.xib" />


### PR DESCRIPTION
- added `Entitlements.plist`
- cleared `Application.cs`
- updated `CFBundleIdentifier`

After launch the app showed an error message that it couldn't register push notifications. There were two reasons:
- Entitlements.plist wasn't exist;
- there were wrong "BundleIdentifier" and developer certificate;
Also I updated the `CFBundleIdentifier` key because we couldn't register the application with `com.*.notifications` key because of Apple limitation (as I understood).
