### PR TITLE
set ui elements on the uithread after asking for permission

### DIFF
--- a/Sound/Sound/SoundViewController.cs
+++ b/Sound/Sound/SoundViewController.cs
@@ -95,7 +95,7 @@ namespace Sound
 							PlayRecordedSoundButton.Enabled = false;
 						});
 
-                } else {
+				} else {
 					Console.WriteLine ("YOU MUST ENABLE MICROPHONE PERMISSION");
 				}
 			});

--- a/Sound/Sound/SoundViewController.cs
+++ b/Sound/Sound/SoundViewController.cs
@@ -85,12 +85,17 @@ namespace Sound
 					stopwatch = new Stopwatch ();
 					stopwatch.Start ();
 
-					LengthOfRecordingLabel.Text = string.Empty;
-					RecordingStatusLabel.Text = "Recording";
-					StartRecordingButton.Enabled = false;
-					StopRecordingButton.Enabled = true;
-					PlayRecordedSoundButton.Enabled = false;
-				} else {
+					UIApplication
+						.SharedApplication
+						.BeginInvokeOnMainThread (() => {
+							LengthOfRecordingLabel.Text = string.Empty;
+							RecordingStatusLabel.Text = "Recording";
+							StartRecordingButton.Enabled = false;
+							StopRecordingButton.Enabled = true;
+							PlayRecordedSoundButton.Enabled = false;
+						});
+
+                } else {
 					Console.WriteLine ("YOU MUST ENABLE MICROPHONE PERMISSION");
 				}
 			});

--- a/Sound/Sound/SoundViewController.cs
+++ b/Sound/Sound/SoundViewController.cs
@@ -85,15 +85,13 @@ namespace Sound
 					stopwatch = new Stopwatch ();
 					stopwatch.Start ();
 
-					UIApplication
-						.SharedApplication
-						.BeginInvokeOnMainThread (() => {
-							LengthOfRecordingLabel.Text = string.Empty;
-							RecordingStatusLabel.Text = "Recording";
-							StartRecordingButton.Enabled = false;
-							StopRecordingButton.Enabled = true;
-							PlayRecordedSoundButton.Enabled = false;
-						});
+					BeginInvokeOnMainThread (() => {
+						LengthOfRecordingLabel.Text = string.Empty;
+						RecordingStatusLabel.Text = "Recording";
+						StartRecordingButton.Enabled = false;
+						StopRecordingButton.Enabled = true;
+						PlayRecordedSoundButton.Enabled = false;
+					});
 
 				} else {
 					Console.WriteLine ("YOU MUST ENABLE MICROPHONE PERMISSION");


### PR DESCRIPTION
If permissions hasn't been asked for yet then the callback from this the first time

```C#
 session.RequestRecordPermission(delegate (bool granted)
            {
```

comes back on a background thread causing this code
```C#
LengthOfRecordingLabel.Text = string.Empty;
RecordingStatusLabel.Text = "Recording";
StartRecordingButton.Enabled = false;
StopRecordingButton.Enabled = true;
PlayRecordedSoundButton.Enabled = false; 
```

to throw an exception 