### PR TITLE
[XI] fixed wrong device family

### DIFF
--- a/ios11/DragAndDropDragBoard/DragBoard/Info.plist
+++ b/ios11/DragAndDropDragBoard/DragBoard/Info.plist
@@ -16,7 +16,6 @@
 	<string>11.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
-		<integer>1</integer>
 		<integer>2</integer>
 	</array>
 	<key>UILaunchStoryboardName</key>

--- a/ios11/DragAndDropMastering/DragSource/Info.plist
+++ b/ios11/DragAndDropMastering/DragSource/Info.plist
@@ -16,7 +16,6 @@
 	<string>11.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
-		<integer>1</integer>
 		<integer>2</integer>
 	</array>
 	<key>UILaunchStoryboardName</key>

--- a/ios11/DragAndDropMastering/DropDestination/Info.plist
+++ b/ios11/DragAndDropMastering/DropDestination/Info.plist
@@ -14,7 +14,6 @@
 	<string>11.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
-		<integer>1</integer>
 		<integer>2</integer>
 	</array>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
Fixed wrong device family for Drag&Drop samples. This feature is only supported on the iPad.