### PR TITLE
[XI] fixed wrong device family

### DIFF
--- a/ios11/DragAndDropTableView/TableViewDragAndDrop/Info.plist
+++ b/ios11/DragAndDropTableView/TableViewDragAndDrop/Info.plist
@@ -14,7 +14,6 @@
 	<string>11.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
-		<integer>1</integer>
 		<integer>2</integer>
 	</array>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
Drag&Drop is only supported on the iPad.