### PR TITLE
[XI] improved iCloud container; "DockPicker" sample

### DIFF
--- a/ios8/DocPicker/DocPicker/Entitlements.plist
+++ b/ios8/DocPicker/DocPicker/Entitlements.plist
@@ -8,10 +8,10 @@
 		<string>CloudKit</string>
 	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
-	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+	<string>$(AppIdentifierPrefix)$(CFBundleIdentifier)</string>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
-		<string>iCloud.com.xamarin.docpicker</string>
+		<string>iCloud.$(CFBundleIdentifier)</string>
 	</array>
 </dict>
 </plist>

--- a/ios8/DocPicker/DocPicker/Info.plist
+++ b/ios8/DocPicker/DocPicker/Info.plist
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
-	<true />
+	<true/>
 	<key>MinimumOSVersion</key>
 	<string>9.0</string>
 	<key>UIDeviceFamily</key>
@@ -39,7 +39,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIPrerenderedIcon</key>
-	<true />
+	<true/>
 	<key>CFBundleIconFiles</key>
 	<array>
 		<string>Icon@2x</string>
@@ -62,6 +62,8 @@
 		<string>remote-notification</string>
 	</array>
 	<key>NSUbiquitousContainerIsDocumentScopePublic</key>
-	<true />
+	<true/>
+	<key>CFBundleName</key>
+	<string>DocPicker</string>
 </dict>
 </plist>


### PR DESCRIPTION
- auto-added missed properties to `Info.plist`
- improved `Entitlements.plist` files by adding `$(CFBundleIdentifier)`. It will help us be more flexible with bundle identifier and profiles