### PR TITLE
fix ArgumentNullException when passing null to CopyProperties

### DIFF
--- a/ios11/SamplePhotoApp/Shared/AnimatedImage.cs
+++ b/ios11/SamplePhotoApp/Shared/AnimatedImage.cs
@@ -33,7 +33,7 @@ namespace SamplePhotoApp
 			imageSource = source;
 			FrameCount = imageSource.ImageCount;
 
-			var imageProperties = source.CopyProperties ((CGImageOptions)null);
+			var imageProperties = source.CopyProperties (new CGImageOptions());
 			if (imageProperties != null)
 			{
 				LoopCount = LoopCountForProperties (imageProperties);
@@ -55,7 +55,7 @@ namespace SamplePhotoApp
 			var totalDuration = 0.0;
 			for (var index = 0; index < FrameCount; index++)
 			{
-				var properties = source.CopyProperties ((CGImageOptions)null, index);
+				var properties = source.CopyProperties (new CGImageOptions(), index);
 				if (properties != null)
 				{
 					var time = FrameDelayForProperties (properties);


### PR DESCRIPTION
Passing null to CopyProperties throws this exception
```
{System.ArgumentNullException: Value cannot be null. Parameter name: options   at ImageIO.CGImageSource.CopyProperties (ImageIO.CGImageOptions options) [0x00003] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.12.0.4/src/Xamarin.iOS/ImageIO/CGImageSour…}
```

So I changed it to just pass a default instantiated
```
new CGImageOptions()
```

And now it plays animations without throwing an exception