### PR TITLE
[avcustomedit] Some timing and simplification fixes

### DIFF
--- a/AVCustomEdit/AVCustomEdit/SimpleEditor.cs
+++ b/AVCustomEdit/AVCustomEdit/SimpleEditor.cs
@@ -13,13 +13,19 @@ namespace AVCustomEdit
 
         public List<AVAsset> Clips { get; set; } // array of AVURLAssets
 
-        public List<NSValue> ClipTimeRanges { get; set; } // array of CMTimeRanges stored in NSValues.
+        public List<CMTimeRange> ClipTimeRanges { get; set; }
 
         public TransitionType TransitionType { get; set; }
 
         public CMTime TransitionDuration { get; set; }
 
-        public AVPlayerItem PlayerItem =>  new AVPlayerItem(this.composition) { VideoComposition = this.videoComposition };
+		public AVPlayerItem PlayerItem {
+            get {
+                if (composition == null)
+                    return null;
+                return new AVPlayerItem(this.composition) { VideoComposition = this.videoComposition };
+            }
+        }
 
         private void BuildTransitionComposition(AVMutableComposition mutableComposition, AVMutableVideoComposition mutableVideoComposition)
         {
@@ -30,12 +36,9 @@ namespace AVCustomEdit
             var transitionDuration = this.TransitionDuration;
             foreach (var clipTimeRange in this.ClipTimeRanges)
             {
-                if (clipTimeRange != null)
-                {
-                    var halfClipDuration = clipTimeRange.CMTimeRangeValue.Duration;
-                    halfClipDuration.TimeScale *= 2; // You can halve a rational by doubling its denominator.
-                    transitionDuration = CMTime.GetMinimum(transitionDuration, halfClipDuration);
-                }
+                var halfClipDuration = clipTimeRange.Duration;
+                halfClipDuration.TimeScale *= 2; // You can halve a rational by doubling its denominator.
+                transitionDuration = CMTime.GetMinimum(transitionDuration, halfClipDuration);
             }
 
             // Add two video tracks and two audio tracks.
@@ -55,16 +58,13 @@ namespace AVCustomEdit
             {
                 int alternatingIndex = i % 2; // alternating targets: 0, 1, 0, 1, ...
                 var asset = this.Clips[i];
-                var clipTimeRange = this.ClipTimeRanges[i];
-
-                var timeRangeInAsset = clipTimeRange != null ? clipTimeRange.CMTimeRangeValue
-                                                             : new CMTimeRange { Start = CMTime.Zero, Duration = asset.Duration };
+                var timeRangeInAsset = this.ClipTimeRanges[i];
 
                 var clipVideoTrack = asset.TracksWithMediaType(AVMediaType.Video)[0];
-                compositionVideoTracks[alternatingIndex].InsertTimeRange(timeRangeInAsset, clipVideoTrack, nextClipStartTime, out NSError error);
+                compositionVideoTracks[alternatingIndex].InsertTimeRange(timeRangeInAsset, clipVideoTrack, nextClipStartTime, out _);
 
                 var clipAudioTrack = asset.TracksWithMediaType(AVMediaType.Audio)[0];
-                compositionAudioTracks[alternatingIndex].InsertTimeRange(timeRangeInAsset, clipAudioTrack, nextClipStartTime, out error);
+                compositionAudioTracks[alternatingIndex].InsertTimeRange(timeRangeInAsset, clipAudioTrack, nextClipStartTime, out _);
 
                 // Remember the time range in which this clip should pass through.
                 // First clip ends with a transition.


### PR DESCRIPTION
Running this sample on device with the interpreter has spotted a few
issues in the sample.

* Timing issue: Use `DispatchGroup.Notify` (like sample) instead of
  `Waiting` (it's not the same) and remove the `InvokeOnMainThread`
  since we're already running on that thread. Also uncomment some
  code that, likely, did not work because `Notify` was not used;

* Timing issue: `composition` can be `null` but it triggers an
  `ArgumentNullException` (because the API does not _officially_ accept
   `nil`).

* Enhancement: Set initial capacity of `List<T>` - just like it's
  done in the original sample;

* Simplification: There's no point in checking for `null` values inside
  `List<T>` since that would have triggered an `ArgumentNullException`;

* Simplification" There's no point in converting `CMTimeRange` into
  `NSValue` (and back into `CMTimeRange`). In contrast to `NSArray`
  we can add non-`NSObject` (including value type like struct) inside
  `List<T>`;

* Cleanup: remove ugly `goto` and use `_` for unused `out NSError`

This will fix https://github.com/xamarin/xamarin-macios/issues/5364