### PR TITLE
Fix ColorFeed sample by adding required Info.plist keys

### DIFF
--- a/ios13/RefreshingAndMaintainingYourAppUsingBackgroundTasks/ColorFeed/Info.plist
+++ b/ios13/RefreshingAndMaintainingYourAppUsingBackgroundTasks/ColorFeed/Info.plist
@@ -46,5 +46,15 @@
 	<string>Assets.xcassets/AppIcon.appiconset</string>
 	<key>CFBundleName</key>
 	<string>ColorFeed</string>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.xamarin.ColorFeed.refresh</string>
+		<string>com.xamarin.ColorFeed.cleaning_db</string>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>processing</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
- https://github.com/xamarin/ios-samples/issues/392