### PR TITLE
[UICatalog] Fix ambiguous call in sample

### DIFF
--- a/UICatalog/UICatalog/Controllers/Toolbars/CustomToolbarViewController.cs
+++ b/UICatalog/UICatalog/Controllers/Toolbars/CustomToolbarViewController.cs
@@ -29,7 +29,7 @@ namespace UICatalog
             var toolbarButtonItems = new[]
             {
                 leftButton,
-                new UIBarButtonItem(UIBarButtonSystemItem.FlexibleSpace, null),
+                new UIBarButtonItem(UIBarButtonSystemItem.FlexibleSpace, (EventHandler) null),
                 rightButton
             };
             toolbar.SetItems(toolbarButtonItems, true);


### PR DESCRIPTION
a new API with a similar signature (wrt null) was added in XI 14