### PR TITLE
[SoupChef] Fix build with Xcode 12.2

### DIFF
--- a/ios12/SoupChef/OrderSoupIntentStaticLib/Makefile
+++ b/ios12/SoupChef/OrderSoupIntentStaticLib/Makefile
@@ -5,15 +5,15 @@ TARGET=OrderSoupIntentStaticLib
 
 all: bind
 
-lib$(TARGET)-i386.a:
+lib$(TARGET)-simulator.a:
 	$(XBUILD) -project $(PROJECT) -target $(TARGET) -sdk iphonesimulator -configuration Release clean build
 	-mv $(PROJECT_ROOT)/build/Release-iphonesimulator/lib$(TARGET).a $@
 
-lib$(TARGET)-arm64.a:
+lib$(TARGET)-device.a:
 	$(XBUILD) -project $(PROJECT) -target $(TARGET) -sdk iphoneos -arch arm64 -configuration Release clean build
 	-mv $(PROJECT_ROOT)/build/Release-iphoneos/lib$(TARGET).a $@
 
-lib$(TARGET).a: lib$(TARGET)-i386.a lib$(TARGET)-arm64.a
+lib$(TARGET).a: lib$(TARGET)-simulator.a lib$(TARGET)-device.a
 	xcrun -sdk iphoneos lipo -create -output $@ $^
 
 bind: lib$(TARGET).a

--- a/ios12/SoupChef/OrderSoupIntentStaticLib/OrderSoupIntentStaticLib.xcodeproj/project.pbxproj
+++ b/ios12/SoupChef/OrderSoupIntentStaticLib/OrderSoupIntentStaticLib.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@
 		730228B6210A498000D68C70 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = x86_64;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 9VWFS9Q2KQ;
 				OTHER_LDFLAGS = "-ObjC";
@@ -270,6 +271,7 @@
 		730228B7210A498000D68C70 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = x86_64;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 9VWFS9Q2KQ;
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
Xcode 12.2
- adds `arm64` to the simulator architectures
- removes `i386` from the simulator architectures

`lipo` cannot create a _classic_ fat archive with `arm64` simulator and
`arm64` device slices - since they are the same architecture.

This requires `.xcframework` support which is not yet supported by XI
and XM.

However we can tweak the build to do:
- x86_64 only for simulator, which is the only support arch for XI today
- arm64 for devices

and that makes `lipo` happy and we can continue to have this sample under
test automation.

Note: the original `.a` names were incorrect as they did not match the
architectures that were present in the files. I changed them to mention
the platform.