### PR TITLE
API fixes in NET6 samples

### DIFF
--- a/dotnet/ios/ios12/BreakfastFinder/BreakfastFinder/BreakfastFinder.csproj
+++ b/dotnet/ios/ios12/BreakfastFinder/BreakfastFinder/BreakfastFinder.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
-	<SupportedOSPlatformVersion>12.0</SupportedOSPlatformVersion>
+	  <SupportedOSPlatformVersion>14.0</SupportedOSPlatformVersion>
     <ProvisioningType>manual</ProvisioningType>
   </PropertyGroup>
 </Project>

--- a/dotnet/ios/ios12/BreakfastFinder/BreakfastFinder/BreakfastFinder.csproj
+++ b/dotnet/ios/ios12/BreakfastFinder/BreakfastFinder/BreakfastFinder.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
-	  <SupportedOSPlatformVersion>14.0</SupportedOSPlatformVersion>
+	<SupportedOSPlatformVersion>14.0</SupportedOSPlatformVersion>
     <ProvisioningType>manual</ProvisioningType>
   </PropertyGroup>
 </Project>

--- a/dotnet/ios/ios12/BreakfastFinder/BreakfastFinder/Info.plist
+++ b/dotnet/ios/ios12/BreakfastFinder/BreakfastFinder/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>12.0</string>
+	<string>14.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/dotnet/ios/ios12/BreakfastFinder/BreakfastFinder/ViewController.cs
+++ b/dotnet/ios/ios12/BreakfastFinder/BreakfastFinder/ViewController.cs
@@ -14,7 +14,7 @@ public class ViewController : UIViewController, IAVCaptureVideoDataOutputSampleB
 
         protected CGSize bufferSize = CGSize.Empty;
         protected CALayer? rootLayer = null;
-        static NSString videoDeviceName = AVMediaTypes.Video.GetConstant ()!;
+        static AVMediaTypes videoDeviceName = AVMediaTypes.Video;
 
         public virtual UIView previewView { get; }
         AVCaptureSession session = new AVCaptureSession ();
@@ -45,7 +45,7 @@ public class ViewController : UIViewController, IAVCaptureVideoDataOutputSampleB
         {
                 AVCaptureDeviceInput deviceInput;
 
-                var device = AVMediaTypes.Video.GetConstant ();
+                var device = AVMediaTypes.Video;
 
                 // Select a video device, make an input
                 var videoDevice = AVCaptureDeviceDiscoverySession.Create (
@@ -77,7 +77,7 @@ public class ViewController : UIViewController, IAVCaptureVideoDataOutputSampleB
                         // Add a video data ouptut
                         videoDataOutput.AlwaysDiscardsLateVideoFrames = true;
                         videoDataOutput.WeakVideoSettings = new NSDictionary (CVPixelBuffer.PixelFormatTypeKey, CVPixelFormatType.CV420YpCbCr8BiPlanarFullRange);
-                        videoDataOutput.SetSampleBufferDelegateQueue (this, videoDataOutputQueue);
+                        videoDataOutput.SetSampleBufferDelegate (this, videoDataOutputQueue);
                 }
                 else
                 {
@@ -86,7 +86,7 @@ public class ViewController : UIViewController, IAVCaptureVideoDataOutputSampleB
                         return;
                 }
 
-                var captureConnection = videoDataOutput.ConnectionFromMediaType (videoDeviceName);
+                var captureConnection = videoDataOutput.ConnectionFromMediaType (videoDeviceName.GetConstant());
                 if (captureConnection is null)
                 {
                         Console.WriteLine ($"Could not connection video output");

--- a/dotnet/ios/ios12/VisionObjectTrack/VisionObjectTrack/AssetsViewController.cs
+++ b/dotnet/ios/ios12/VisionObjectTrack/VisionObjectTrack/AssetsViewController.cs
@@ -191,7 +191,7 @@ public partial class AssetsViewController : UICollectionViewController
                                 DeliveryMode = PHVideoRequestOptionsDeliveryMode.HighQualityFormat
                         };
 
-                        imageManager.RequestAvAsset (asset, videoOptions, (avAsset, _, __) =>
+                        imageManager.RequestAVAsset (asset, videoOptions, (avAsset, _, __) =>
                         {
                                 if (avAsset is not null)
                                 {


### PR DESCRIPTION
I was able to build the 3 samples here (plus a PR I updated) against the latest macios and have zero availability warnings after these fixes. 

They come in two flavors:

- Compile errors caused by last minute API breaks
- Bumping the minimum version because the availability warnings were legit.